### PR TITLE
Throw syntax errors instead of semantic errors upon compilation failure 

### DIFF
--- a/typestring.js
+++ b/typestring.js
@@ -45,9 +45,9 @@ define(['typescript-api'], function (TypeScript) {
         output += !!current ? current.text : '';
       }
 
-      var diagnostics = compiler.getSemanticDiagnostics(filename);
-      if (!output && diagnostics.length) {
-        throw new Error(diagnostics[0].text());
+      var diagnostics = compiler.getSyntacticDiagnostics(filename);
+      if (diagnostics.length) {
+        throw diagnostics;
       }
 
       return output;


### PR DESCRIPTION
The errors I got were unintelligible. It turned out that the wrong diagnostics were retrieved. Typestring only throws an error when no output is generated, so the _syntactical_ diagnostics (`getSyntacticDiagnostics`) need to be retrieved instead of the _semantic_ diagnostics (`getSyntacticDiagnostics`).

Also, I propose to throw the whole array of syntax errors.
